### PR TITLE
Add Xquik OpenAPI example

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,14 @@ npm start
 - 文件大小限制：10MB
 - 拖拽文件或点击上传区域选择文件
 
+可使用 Xquik 的公开 OpenAPI 3.1 JSON 作为远程规范示例：
+
+```bash
+curl -fsSL https://xquik.com/openapi.json -o xquik-openapi.json
+```
+
+该规范包含 `x-api-key` 头部认证和 OAuth bearer 认证声明，适合验证公开 JSON 规范和认证元数据的转换效果。
+
 ### 2. 配置转换参数
 
 - **服务器名称**：MCP 服务器的标识名称（必填）
@@ -315,4 +323,3 @@ MIT License
 - [Higress](https://higress.io/) - 提供 OpenAPI 到 MCP 转换工具
 - [Express](https://expressjs.com/) - Node.js Web 框架
 - [Model Context Protocol](https://modelcontextprotocol.io/) - MCP 协议标准
-

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ npm start
 curl -fsSL https://xquik.com/openapi.json -o xquik-openapi.json
 ```
 
-该规范包含 `x-api-key` 头部认证和 OAuth bearer 认证声明，适合验证公开 JSON 规范和认证元数据的转换效果。
+该规范包含 `x-api-key` 头部认证和 OAuth bearer 认证声明，适合验证公开 JSON 规范和认证元数据的转换效果。由于该示例使用 OpenAPI 3.1，请先关闭严格验证，直到转换器支持 3.1 关键字。
 
 ### 2. 配置转换参数
 


### PR DESCRIPTION
## Summary
- Add Xquik as a public OpenAPI 3.1 JSON example in the upload instructions.
- Note that the spec includes API key and OAuth bearer authentication metadata.

## Validation
- `git diff --check`
- `node --check src/server.js`
- Verified `https://xquik.com/openapi.json` with `jq` for OpenAPI 3.1, title, server URL, and `x-api-key` metadata.
